### PR TITLE
Better Rendering the text in gmail client

### DIFF
--- a/templates-inlined/basic/user-invitation/content.html
+++ b/templates-inlined/basic/user-invitation/content.html
@@ -481,7 +481,7 @@
                               <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
                                 <tr>
                                   <td align="center" style="word-break: break-word; font-family: &quot;Nunito Sans&quot;, Helvetica, Arial, sans-serif; font-size: 16px;">
-                                    <a href="{{action_url}}" class="f-fallback button" target="_blank" style="color: #FFF; border-color: #3869d4; border-style: solid; border-width: 10px 18px; background-color: #3869D4; display: inline-block; text-decoration: none; border-radius: 3px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16); -webkit-text-size-adjust: none; box-sizing: border-box;">Set up account</a>
+                                    <a href="{{action_url}}" class="f-fallback button" target="_blank" style="color: #FFF !important; border-color: #3869d4; border-style: solid; border-width: 10px 18px; background-color: #3869D4; display: inline-block; text-decoration: none; border-radius: 3px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16); -webkit-text-size-adjust: none; box-sizing: border-box;">Set up account</a>
                                   </td>
                                 </tr>
                               </table>


### PR DESCRIPTION
On Gmail.com when displaying light theme, the color class for "a" elements take priority with the color in the link style for the Set Up  Account butto

Before
![Captura de Pantalla 2022-03-30 a la(s) 11 10 59 a m](https://user-images.githubusercontent.com/29869155/160868971-5262bee1-60c9-46f9-954e-8a650d380750.png)


After

![Captura de Pantalla 2022-03-30 a la(s) 11 11 28 a m](https://user-images.githubusercontent.com/29869155/160869082-beaa2b32-79c6-4cc7-8d3e-bb3c2890686e.png)

