### PR TITLE
Proper render on rtl email clients

### DIFF
--- a/templates/basic-full/receipt/content.html
+++ b/templates/basic-full/receipt/content.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="x-apple-disable-message-reformatting" />
@@ -436,7 +436,7 @@
     </style>
   <![endif]-->
   </head>
-  <body>
+  <body dir="ltr">
     <span class="preheader">This is a receipt for your recent purchase on {{ purchase_date }}. No payment is due with this receipt.</span>
     <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
       <tr>


### PR DESCRIPTION
The following template wouldn't render properly on email clients set to "right to left" languages, such as Hebrew. The following changes fixes that